### PR TITLE
ADA Disclaimer and additional item under General Contact for email

### DIFF
--- a/src/app/calendar-event/calendar-event.component.css
+++ b/src/app/calendar-event/calendar-event.component.css
@@ -196,7 +196,7 @@ h4.right-content-calendar--title:after {
   border: 1px solid #0d94d0;
   color: #fff;
   width: 100%;
-  margin-bottom: 10px;
+  margin: 15px 0 10px 0;
 }
 
 .btn.blue:focus {

--- a/src/app/calendar-event/calendar-event.component.html
+++ b/src/app/calendar-event/calendar-event.component.html
@@ -78,7 +78,10 @@
               </div>
             </div>
             <div class="detail-item" >
-              <div class="phone"><a href="tel:{{event?.contactPhone}}">{{event?.contactEmail}}</a></div>
+              <div class="phone">
+                <a *ngIf="!event?.contactName" href="mailto:{{event?.contactEmail}}">{{event?.contactEmail}}</a>
+                <a *ngIf="event?.contactName" href="mailto:{{event?.contactEmail}}">{{event?.contactName}}</a>
+              </div>
             </div>
           </div>
 

--- a/src/app/calendar-event/calendar-event.component.html
+++ b/src/app/calendar-event/calendar-event.component.html
@@ -88,7 +88,7 @@
 
       <span class="ada-text">If you need materials in accessible format, sign language interpreters, and/or any accommodation to participate in this meeting, please call <span class="ada-number"><a href="tel:{{event?.adaPhone}}">{{event?.adaPhone}}</a></span> or email <span class="email"><a href="mailto:{{event?.adaEmail}}" *ngIf="!event?.adaName">{{event?.adaEmail}}</a><a href="mailto:{{event?.adaEmail}}" *ngIf="event?.adaName">{{event?.adaName}}</a></span> at least five days in advance of the meeting.</span>
 
-      <a *ngIf='(event?.url.url | json) !== "{}"' class="waves-effect wave-light btn blue" target='_blank' href="{{event?.url.url}}" tabindex="0">Event Details</a>
+      <a *ngIf='event?.url.url' class="waves-effect wave-light btn blue" target='_blank' href="{{event?.url.url}}" tabindex="0">Event Details</a>
 
     </div>
   </div>

--- a/src/app/calendar-event/calendar-event.component.html
+++ b/src/app/calendar-event/calendar-event.component.html
@@ -46,7 +46,7 @@
           </div>
         </div>
 
-        <div class="col s12 m4 offset-m1 right-content-calendar">
+        <div class="col s12 m4 offset-m1 right-content-calendar" *ngIf="(event?.contactEmail || event?.contactName || event?.contactPhone)">
           <h4 class="right-content-calendar--title">General Contact</h4>
 
           <div class="list-item middle" *ngIf="event?.contactName">
@@ -71,7 +71,7 @@
             </div>
           </div>
 
-          <div class="list-item middle" *ngIf="event?.contactEmail">
+          <div class="list-item middle" *ngIf="(event?.contactEmail && !event?.contactName)">
             <div class="detail-item">
               <div class="icon-container">
                 <i class="fa fa-envelope" aria-hidden="true"></i>
@@ -79,8 +79,7 @@
             </div>
             <div class="detail-item" >
               <div class="phone">
-                <a *ngIf="!event?.contactName" href="mailto:{{event?.contactEmail}}">{{event?.contactEmail}}</a>
-                <a *ngIf="event?.contactName" href="mailto:{{event?.contactEmail}}">{{event?.contactName}}</a>
+                <a href="mailto:{{event?.contactEmail}}">{{event?.contactEmail}}</a>
               </div>
             </div>
           </div>

--- a/src/app/calendar-event/calendar-event.component.html
+++ b/src/app/calendar-event/calendar-event.component.html
@@ -49,35 +49,35 @@
         <div class="col s12 m4 offset-m1 right-content-calendar">
           <h4 class="right-content-calendar--title">General Contact</h4>
 
-          <div class="list-item middle">
+          <div class="list-item middle" *ngIf="event?.contactName">
             <div class="detail-item">
               <div class="icon-container">
                 <i class="fa fa-user" aria-hidden="true"></i>
               </div>
             </div>
-            <div class="detail-item" *ngIf="event?.contactEmail">
-              <div class="event-name"><a href="mailto:{{event?.contactEmail}}">{{event?.contactName}}</a></div>
+            <div class="detail-item">
+              <div class="event-name"><a *ngIf="event?.contactEmail" href="mailto:{{event?.contactEmail}}">{{event?.contactName}}</a><span *ngIf="!event?.contactEmail">{{event?.contactName}}</span></div>
             </div>
           </div>
 
-          <div class="list-item middle">
+          <div class="list-item middle" *ngIf="event?.contactPhone">
             <div class="detail-item">
               <div class="icon-container">
                 <i class="fa fa-phone" aria-hidden="true"></i>
               </div>
             </div>
-            <div class="detail-item" *ngIf="event?.contactPhone">
+            <div class="detail-item">
               <div class="phone"><a href="tel:{{event?.contactPhone}}">{{event?.contactPhone}}</a></div>
             </div>
           </div>
 
-          <div class="list-item middle">
+          <div class="list-item middle" *ngIf="event?.contactEmail">
             <div class="detail-item">
               <div class="icon-container">
                 <i class="fa fa-envelope" aria-hidden="true"></i>
               </div>
             </div>
-            <div class="detail-item" *ngIf="event?.contactEmail">
+            <div class="detail-item" >
               <div class="phone"><a href="tel:{{event?.contactPhone}}">{{event?.contactEmail}}</a></div>
             </div>
           </div>
@@ -88,7 +88,7 @@
 
       <span class="ada-text">If you need materials in accessible format, sign language interpreters, and/or any accommodation to participate in this meeting, please call <span class="ada-number"><a href="tel:{{event?.adaPhone}}">{{event?.adaPhone}}</a></span> or email <span class="email"><a href="mailto:{{event?.adaEmail}}" *ngIf="!event?.adaName">{{event?.adaEmail}}</a><a href="mailto:{{event?.adaEmail}}" *ngIf="event?.adaName">{{event?.adaName}}</a></span> at least five days in advance of the meeting.</span>
 
-      <a *ngIf='(event?.url | json) !== "{}"' class="waves-effect wave-light btn blue" target='_blank' href="{{event?.url.url}}" tabindex="0">Event Details</a>
+      <a *ngIf='(event?.url.url | json) !== "{}"' class="waves-effect wave-light btn blue" target='_blank' href="{{event?.url.url}}" tabindex="0">Event Details</a>
 
     </div>
   </div>

--- a/src/app/calendar-event/calendar-event.component.html
+++ b/src/app/calendar-event/calendar-event.component.html
@@ -15,6 +15,7 @@
     <div class="content-container">
 
       <div class="row">
+
         <div class="col s12 m7 content-main-calendar">
           <div class="short-description" [innerHTML]='event?.description'>
           </div>
@@ -43,16 +44,15 @@
               <div class="prive" *ngIf='event?.isFree'>This event is free.</div>
             </div>
           </div>
-
-
         </div>
+
         <div class="col s12 m4 offset-m1 right-content-calendar">
           <h4 class="right-content-calendar--title">General Contact</h4>
 
           <div class="list-item middle">
             <div class="detail-item">
               <div class="icon-container">
-                <i class="fa fa-map-marker" aria-hidden="true"></i>
+                <i class="fa fa-user" aria-hidden="true"></i>
               </div>
             </div>
             <div class="detail-item" *ngIf="event?.contactEmail">
@@ -70,15 +70,25 @@
               <div class="phone"><a href="tel:{{event?.contactPhone}}">{{event?.contactPhone}}</a></div>
             </div>
           </div>
+
+          <div class="list-item middle">
+            <div class="detail-item">
+              <div class="icon-container">
+                <i class="fa fa-envelope" aria-hidden="true"></i>
+              </div>
+            </div>
+            <div class="detail-item" *ngIf="event?.contactEmail">
+              <div class="phone"><a href="tel:{{event?.contactPhone}}">{{event?.contactEmail}}</a></div>
+            </div>
+          </div>
+
         </div>
-
-
-        <a *ngIf='(event?.url | json) !== "{}"' class="waves-effect wave-light btn blue" target='_blank' href="{{event?.url.url}}" tabindex="0">Event Details</a>
-
-        <span class="ada-text">If you need materials in accessible format, sign language interpreters, and/or any accommodation to participate in this meeting, please call <span class="ada-number"><a href="tel:{{event?.adaPhone}}">{{event?.adaPhone}}</a></span> or email <span class="email"><a href="mailto:{{event?.adaEmail}}" *ngIf="!event?.adaName">{{event?.adaEmail}}</a><a href="mailto:{{event?.adaEmail}}" *ngIf="event?.adaName">{{event?.adaName}}</a></span> at least five days in advance of the meeting.</span>
 
       </div>
 
+      <span class="ada-text">If you need materials in accessible format, sign language interpreters, and/or any accommodation to participate in this meeting, please call <span class="ada-number"><a href="tel:{{event?.adaPhone}}">{{event?.adaPhone}}</a></span> or email <span class="email"><a href="mailto:{{event?.adaEmail}}" *ngIf="!event?.adaName">{{event?.adaEmail}}</a><a href="mailto:{{event?.adaEmail}}" *ngIf="event?.adaName">{{event?.adaName}}</a></span> at least five days in advance of the meeting.</span>
+
+      <a *ngIf='(event?.url | json) !== "{}"' class="waves-effect wave-light btn blue" target='_blank' href="{{event?.url.url}}" tabindex="0">Event Details</a>
 
     </div>
   </div>


### PR DESCRIPTION
Took ADA disclaimer and the Event Details button out of the row. This should fix the display issue with it floating underneath the General Contact.

Moreover, added an additional item on the right when there's only an email. The logic is still not in place to show and hide accordingly.